### PR TITLE
Group overlay packages into single attribute

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -2,13 +2,20 @@ self: super:
 
 with super.lib;
 
-rec {
-  hello = self.callPackage ./pkgs/hello { };
+let
+  override = rec {
+    # These packages will hide packages in the top level nixpkgs
+    hello = self.callPackage ./pkgs/hello { };
 
-  swift = self.callPackage ./pkgs/swift { };
-
-  replitPackages = {
-    jdt-language-server = self.callPackage ./pkgs/jdt-language-server { };
+    swift = self.callPackage ./pkgs/swift { };
   };
-}
+in {
+  replitPackages = rec {
+    # Any other packages should go in the replitPackages namespace
+    jdt-language-server = self.callPackage ./pkgs/jdt-language-server { };
+
+    # The override packages are injected into the replitPackages namespace as
+    # well so they can all be built together
+  } // override;
+} // override
 


### PR DESCRIPTION
We need to be able to build all of the custom packages in this overlay into our cache. This adds a `replitPackages` attribute to the top level of the overlay that contains all of the packages specified in this overlay. Packages in `replitPackages.override` will also be placed in the top level so they can override packages in upstream nixpkgs.