### PR TITLE
Build all of replitPackages in release.nix

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -4,9 +4,4 @@ let
 
   pkgs = import ./default.nix { };
 
-in
-with pkgs; {
-  inherit swift;
-
-  inherit (replitPackages) jdt-language-server replbox;
-}
+in pkgs.replitPackages


### PR DESCRIPTION
This makes it so we don't have to keep updating this extra file.