### PR TITLE
Exclude build from output

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -20,6 +20,7 @@ tar -czvf $channel.tar.gz \
   --exclude='./.github' \
   --exclude='./.semaphore' \
   --exclude='./.gitignore' \
+  --exclude='./build.sh' \
   $ignore \
   ./
 


### PR DESCRIPTION
Including build.sh in the overlay breaks nix. This removes it.