### PR TITLE
Java DAP prerelease cleanup

### DIFF
--- a/pkgs/java-debug/bind-address.patch
+++ b/pkgs/java-debug/bind-address.patch
@@ -1,0 +1,65 @@
+From a97603787acc1430b7e129ec3da9dea9b549efb0 Mon Sep 17 00:00:00 2001
+From: lhchavez <lhchavez@lhchavez.com>
+Date: Tue, 8 Jun 2021 17:03:38 +0000
+Subject: [PATCH] Add a System property to allow binding to a specific
+ interface/port
+
+This change adds support to read the value of the
+`com.microsoft.java.debug.serverAddress` system property when
+constructing the JavaDebugServer. This allows callers to specify a
+specific interface to bind to (e.g. `localhost:0`), a specific port
+(e.g. `:12345`), or both (e.g. `localhost:12345`).
+---
+ .../plugin/internal/JavaDebugServer.java      | 29 ++++++++++++++++++-
+ 1 file changed, 28 insertions(+), 1 deletion(-)
+
+diff --git a/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/plugin/internal/JavaDebugServer.java b/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/plugin/internal/JavaDebugServer.java
+index 32ab195b..12c2955c 100644
+--- a/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/plugin/internal/JavaDebugServer.java
++++ b/com.microsoft.java.debug.plugin/src/main/java/com/microsoft/java/debug/plugin/internal/JavaDebugServer.java
+@@ -12,8 +12,10 @@
+ package com.microsoft.java.debug.plugin.internal;
+ 
+ import java.io.IOException;
++import java.net.InetAddress;
+ import java.net.ServerSocket;
+ import java.net.Socket;
++import java.net.UnknownHostException;
+ import java.util.concurrent.ExecutorService;
+ import java.util.concurrent.SynchronousQueue;
+ import java.util.concurrent.ThreadPoolExecutor;
+@@ -33,8 +35,33 @@
+     private ExecutorService executor = null;
+ 
+     private JavaDebugServer() {
++        int port = 0;
++        InetAddress bindAddr = null;
++        String serverAddress = System.getProperty("com.microsoft.java.debug.serverAddress");
++        if (serverAddress != null) {
++            int portIndex = serverAddress.lastIndexOf(':');
++            if (portIndex == -1) {
++                logger.log(Level.SEVERE, String.format("Malformed server address \"%s\": missing port", serverAddress));
++                return;
++            }
++            try {
++                port = Integer.parseInt(serverAddress.substring(portIndex + 1));
++            } catch (NumberFormatException e) {
++                logger.log(Level.SEVERE, String.format("Malformed server address \"%s\": %s", serverAddress, e.toString()), e);
++                return;
++            }
++
++            if (portIndex > 0) {
++                try {
++                    bindAddr = InetAddress.getByName(serverAddress.substring(0, portIndex));
++                } catch (UnknownHostException e) {
++                    logger.log(Level.SEVERE, String.format("Invalid server address \"%s\": %s", serverAddress, e.toString()), e);
++                    return;
++                }
++            }
++        }
+         try {
+-            this.serverSocket = new ServerSocket(0, 1);
++            this.serverSocket = new ServerSocket(port, 1, bindAddr);
+         } catch (IOException e) {
+             logger.log(Level.SEVERE, String.format("Failed to create Java Debug Server: %s", e.toString()), e);
+         }

--- a/pkgs/java-debug/debug-plugin.nix
+++ b/pkgs/java-debug/debug-plugin.nix
@@ -20,6 +20,7 @@ in stdenv.mkDerivation {
     sha256 = "1syrzp8syisnd8fkj3lis5rv83chzj4gwm63ygib41c428yyw20a";
   };
 
+  patches = [ ./bind-address.patch ];
   buildInputs = [ maven graalvm11-ce ];
   buildPhase = ''
     # Maven tries to grab lockfiles in the repository, so it has to be writeable

--- a/pkgs/java-debug/default.nix
+++ b/pkgs/java-debug/default.nix
@@ -2,6 +2,7 @@
 , callPackage
 , makeWrapper
 , jdt-language-server
+, python3
 }:
 let
   debug-plugin = callPackage ./debug-plugin.nix { };
@@ -12,11 +13,12 @@ in stdenv.mkDerivation {
   unpackPhase = "true";
   dontBuild = true;
 
-  #"-Dcom.microsoft.java.debug.serverAddress=localhost:0"
+  nativeBuildInputs = [ python3 ];
   buildInputs = [ makeWrapper ];
   installPhase = ''
     mkdir -p $out/bin
     cp ${./java-dap} $out/bin/java-dap
+    patchShebangs $out/bin/java-dap
 
     makeWrapper $out/bin/java-dap $out/bin/java-debug \
       --add-flags --use-ephemeral-port \


### PR DESCRIPTION
- Explicitly specify python3 as a dependency
- Add java-debug patch from https://github.com/microsoft/java-debug/pull/379