### PR TITLE
Upgrade jdt-language-server to 1.9.0

### DIFF
--- a/pkgs/java-debug/repo.nix
+++ b/pkgs/java-debug/repo.nix
@@ -29,5 +29,5 @@ stdenv.mkDerivation {
  dontFixup = true;
  outputHashAlgo = "sha256";
  outputHashMode = "recursive";
- outputHash = "0xngm83ay9sw9iqkjmampwcrq1ilp9w46lhl7xpknkwx8yw77ig1";
+ outputHash = "sha256-hvgyOruQK9kAuUJdE5XUtebR04g29z3WlHLsRRbjet4";
 }

--- a/pkgs/jdt-language-server/default.nix
+++ b/pkgs/jdt-language-server/default.nix
@@ -10,12 +10,12 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "jdt-language-server";
-  version = "1.6.0";
-  timestamp = "202111261512";
+  version = "1.9.0";
+  timestamp = "202203031534";
 
   src = fetchurl {
     url = "https://download.eclipse.org/jdtls/milestones/${version}/jdt-language-server-${version}-${timestamp}.tar.gz";
-    sha256 = "166nbjwkgi4j9fkfsgggl92cgdw3mjf8zphm32bs07i5mpq20db8";
+    sha256 = "1irg8fzrw016js9zbcnq35lagb66zdgs800y0v8pz09vrcjikbxq";
   };
 
   sourceRoot = ".";


### PR DESCRIPTION
We're a few versions behind (1.6.0) and we've been experiencing issues with the Java LSP. It probably won't fix all of our issues but upgrading to the latest version of our LSP server is a good start!