### PR TITLE
Don't include override attr set in replitPackages

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -18,15 +18,12 @@ let
           --suffix PATH : ${self.lib.makeBinPath [ self.nodePackages.typescript ]}
       '';
     };
-
-  override = {
-    # These packages will hide packages in the top level nixpkgs
-    nodePackages = super.nodePackages // {
-      inherit typescript-language-server;
-    };
-  };
 in
 {
+  nodePackages = super.nodePackages // {
+    inherit typescript-language-server;
+  };
+
   replitPackages = rec {
     # Version string set when building overlay
     version = "GIT_SHA_HERE";
@@ -52,8 +49,8 @@ in
 
     # The override packages are injected into the replitPackages namespace as
     # well so they can all be built together
-  } // override // self.pkgs.lib.optionalAttrs (self.pkgs ? graalvm17-ce) {
+  } // self.pkgs.lib.optionalAttrs (self.pkgs ? graalvm17-ce) {
     java-language-server = self.callPackage ./pkgs/java-language-server { };
   };
-} // override
+}
 


### PR DESCRIPTION
Since we now override `nodePackages`, we don't want to add all nixpkgs NodePackages to replitPackages as it makes hydra do more work.

Let's remove the extra `override` attr set and inline it into the top-level attr-set that is returned in the overlay. its more clear about what is happening and makes it so hydra does less work.