### PR TITLE
[typescript-language-server] Pass  to typescript lib directory

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -15,7 +15,8 @@ let
       nativeBuildInputs = [ self.makeWrapper ];
       postInstall = ''
         wrapProgram "$out/bin/typescript-language-server" \
-          --suffix PATH : ${self.lib.makeBinPath [ self.nodePackages.typescript ]}
+          --suffix PATH : ${self.lib.makeBinPath [ self.nodePackages.typescript ]} \
+          --add-flags "--tsserver-path ${self.nodePackages.typescript}/lib/node_modules/typescript/lib/"
       '';
     };
 in

--- a/pkgs/java-debug/repo.nix
+++ b/pkgs/java-debug/repo.nix
@@ -29,5 +29,5 @@ stdenv.mkDerivation {
  dontFixup = true;
  outputHashAlgo = "sha256";
  outputHashMode = "recursive";
- outputHash = "sha256-aEDJblQ9/Niz0YBuPeUrnZuwI+3iTYUEkvlnehhavx0=";
+ outputHash = "sha256-myCgCPxkoIPAF9BAEad0rOW/KKe+spJi6Kf1CYZ5h0E=";
 }


### PR DESCRIPTION
Newer versions of typescript-language-server are unable to find `tsserver` from the `PATH`. For now, let's hardcode the directory of `tsserver` using the `--tsserver-path` flag so we can get a newer version of typescript-language-server out.

# Test Plan

* Fork this repl: https://replit.com/@ConnorBrewster/typescript-language-server-debug#index.js
    * It has this branch hooked up to `replit.nix`
* Wait for Nix environment to load
    * It will take a while
* LSP works in `index.js`
```
~/typescript-language-server-debug$ typescript-language-server --version
0.9.6
```
![image](https://user-images.githubusercontent.com/9086315/166860607-b305082d-c93c-459c-a2f4-414566936fe8.png)


Canary
* Make sure things work on canary before deploying to prod
