### PR TITLE
channels: use better upstream branches, and update

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -45,6 +45,8 @@ blocks:
       env_vars:
         - name: NIXPKGS_ALLOW_INSECURE
           value: "1"
+        - name: NIXPKGS_ALLOW_UNFREE
+          value: "1"
       jobs:
         - name: Build packages
           matrix:

--- a/add.sh
+++ b/add.sh
@@ -1,11 +1,11 @@
-#!/bin/sh
+#!/usr/bin/env bash
 channel=$1
 
 # Add the channel to the overlay
-nix-shell -p niv --run "niv add nixos/nixpkgs --name nixpkgs-$channel -b release-$channel"
+nix-shell -p niv --run "niv add nixos/nixpkgs --name nixpkgs-$channel -b nixos-$channel"
 
 # Add the channel to the update script
-echo "nix-shell -p niv --run 'niv update nixpkgs-$channel -b release-$channel'" >> update.sh
+echo "nix-shell -p niv --run 'niv update nixpkgs-$channel -b nixos-$channel'" >> update.sh
 
 # Add the channel to hydra
 cp hydra/release-21.11.nix hydra/release-$channel.nix

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -12,27 +12,27 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs-21.11": {
-        "branch": "release-21.11",
+        "branch": "nixos-21.11",
         "description": "Nix Packages collection",
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4275a321beab5a71872fb7a5fe5da511bb2bec73",
-        "sha256": "1p3pn7767ifbg08nmgjd93iqk0z87z4lv29ypalj9idwd3chsm69",
+        "rev": "eabc38219184cc3e04a974fe31857d8e0eac098d",
+        "sha256": "04ffwp2gzq0hhz7siskw6qh9ys8ragp7285vi1zh8xjksxn1msc5",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/4275a321beab5a71872fb7a5fe5da511bb2bec73.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/eabc38219184cc3e04a974fe31857d8e0eac098d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs-22.05": {
-        "branch": "release-22.05",
+        "branch": "nixos-22.05",
         "description": "Nix Packages collection",
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3aa2752ec5cf8300d9f2493cf24841e2131cf71e",
-        "sha256": "081jklh6inf97cikyqcxcn7cwsbxw4xbdbbwsqdsd71izcgf2y8a",
+        "rev": "e09913998d89659044c29ef5df4a86542e78a2ef",
+        "sha256": "1483xm3gkv90jd300dqm29g3wqxv8kr93k86m21a984mgk6irgjh",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/3aa2752ec5cf8300d9f2493cf24841e2131cf71e.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/e09913998d89659044c29ef5df4a86542e78a2ef.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs-legacy": {
@@ -47,15 +47,15 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs-unstable": {
-        "branch": "nixos-unstable",
+        "branch": "nixpkgs-unstable",
         "description": "Nix Packages collection",
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a72d7811be1162dd6804c4e36e5402d76fb6e921",
-        "sha256": "1isscmp50759g0jg09p9067l0l29i3zp61zxfc4r03mz3kspd1g5",
+        "rev": "a2d2f70b82ada0eadbcb1df2bca32d841a3c1bf1",
+        "sha256": "0w838qbbfvijbqb4h97br1q635r4656771nw080lbcy74hxdzh0i",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/a72d7811be1162dd6804c4e36e5402d76fb6e921.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/a2d2f70b82ada0eadbcb1df2bca32d841a3c1bf1.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "prybar": {

--- a/overlay.nix
+++ b/overlay.nix
@@ -72,10 +72,6 @@ rec {
 
     dapPython = super.callPackage ./pkgs/dapPython { };
 
-    # The override packages are injected into the replitPackages namespace as
-    # well so they can all be built together
-  } // self.pkgs.lib.optionalAttrs (self.pkgs ? graalvm17-ce) {
-    java-language-server = self.callPackage ./pkgs/java-language-server { };
   };
 }
 

--- a/update.sh
+++ b/update.sh
@@ -1,5 +1,4 @@
-#!/bin/sh
-nix-shell -p niv --run 'niv update nixpkgs-21.11 -b release-21.11'
-nix-shell -p niv --run 'niv update nixpkgs-unstable -b nixos-unstable'
-
-nix-shell -p niv --run 'niv update nixpkgs-22.05 -b release-22.05'
+#!/usr/bin/env bash
+nix-shell -p niv --run 'niv update nixpkgs-unstable -b nixpkgs-unstable'
+nix-shell -p niv --run 'niv update nixpkgs-21.11 -b nixos-21.11'
+nix-shell -p niv --run 'niv update nixpkgs-22.05 -b nixos-22.05'


### PR DESCRIPTION
* This updates unstable, 21.11, and 22.05 channels to their latest versions.
* For the stable channels, it uses the nixos-xx.xx branches that have passed upstream CI, instead of the release-xx.xx branches that have not.
* For the unstable channel, it switches to nixpkgs-unstable, which better matches the name. nixpkgs-unstable is updated more often than nixos-unstable and has less CI checks done, but those CI checks are mostly about the graphical systems and NixOS itself, so I don't think they're appropriate for our use case.
* remove java-language-server, which does not build with nixpkgs-unstable and we do not use it in the java templates