### PR TITLE
Updated prybar rev

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -76,10 +76,10 @@
         "homepage": "",
         "owner": "replit",
         "repo": "prybar",
-        "rev": "49e624c8eb613f77c922227c5a4bc4916ee1a782",
-        "sha256": "0wqab3kqdcfhcsnkly176fb0ix5wccn2lqxlb02i8sk4dazgkg8j",
+        "rev": "e0d9a529868d3c03a1fc0bfdd56877568545bde9",
+        "sha256": "14hya5dsj7kwarqmkw6rmlklf39kq55f3pcz1sli4m15dkb1505w",
         "type": "tarball",
-        "url": "https://github.com/replit/prybar/archive/49e624c8eb613f77c922227c5a4bc4916ee1a782.tar.gz",
+        "url": "https://github.com/replit/prybar/archive/e0d9a529868d3c03a1fc0bfdd56877568545bde9.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
#Why?

We updated prybar to update it's nixpkgs version to 22.11. Now updated the its input source in this repo.

# Change

Did `niv update prybar` and this is the change it made.

# Test

Run the nix cache updated job again and check that prybar-python310 when retrieved from `pkgs.replitPackages.prybar-python310` is the one that depends on glibc-2.35.