### PR TITLE
enable test building overlay packages with other channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ You can also fork [this repl](https://replit.com/@ZachAtReplit/overlay), which
 contains the overlay repository, and allows testing packages from the overlay
 directly in `replit.nix`.
 
+## Building the overlay for a particular channel
+
+You can build a package for a particular channel like this:
+
+```
+nix-build --argstr channelName nixpkgs-22.11 -A nodePackages.typescript-language-server
+```
+
 ## Updating the overlay base
 You can update the pinned base channels by running `./update.sh`. The update
 script will use niv to update the pinned channels to the latest revisions

--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,6 @@
 { sources ? import nix/sources.nix
-, channel ? sources."nixpkgs-unstable"
+, channelName ? "nixpkgs-unstable"
+, channel ? sources.${channelName}
 }:
 let
   overlay = (import ./overlay.nix) {


### PR DESCRIPTION
I wanted to test building a package with the stable channel and it was hard. This makes it a little easier.