### PR TITLE
update nixpkgs-unstable channel

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -64,10 +64,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a2d2f70b82ada0eadbcb1df2bca32d841a3c1bf1",
-        "sha256": "0w838qbbfvijbqb4h97br1q635r4656771nw080lbcy74hxdzh0i",
+        "rev": "9e0eed654c705c7cafe192a8eba1610217f70544",
+        "sha256": "1qyfqcrvdkncgx21a48lki3qs3h2wxppjkxmbrmjny3wgv30bxyx",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/a2d2f70b82ada0eadbcb1df2bca32d841a3c1bf1.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/9e0eed654c705c7cafe192a8eba1610217f70544.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "prybar": {


### PR DESCRIPTION
We haven't bumped it in a while, and we'd like to get urbit on Replit.