### PR TITLE
Updates to 3 modules to prep for prod templates

### DIFF
--- a/modules/go.nix
+++ b/modules/go.nix
@@ -8,23 +8,12 @@
     gopls
   ];
 
-  replit.runners.go-build = rec {
-    name = "go build";
-    language = "go";
-    extensions = [".go"];
-    
-    start = "./main";
-    compile = "${pkgs.go}/bin/go build -o ${start}";
-    fileParam = false;
-  };
-
   replit.runners.go-run = {
     name = "go run";
     language = "go";
-    extensions = [".go"];
 
-    start = "${pkgs.go}/bin/go run .";
-    fileParam = false;
+    start = "${pkgs.go}/bin/go run $file";
+    fileParam = true;
   };
 
   replit.formatters.go-fmt = {
@@ -38,7 +27,6 @@
   replit.languageServers.gopls = {
     name = "gopls";
     language = "go";
-    extensions = [".go"];
     
     start = "${pkgs.gopls}/bin/gopls";
   };

--- a/modules/rust.nix
+++ b/modules/rust.nix
@@ -1,4 +1,13 @@
 { pkgs, ... }:
+let cargoRun = pkgs.writeScriptBin "cargo_run" ''
+  if [ ! -f "$HOME/$REPL_SLUG/Cargo.toml" ]; then
+    NAME=$(echo $REPL_SLUG | sed -r 's/([a-z0-9])([A-Z])/\1_\2/g'| tr '[:upper:]' '[:lower:]')
+    ${pkgs.cargo}/bin/cargo init --name=$NAME
+  fi
+
+  ${pkgs.cargo}/bin/cargo run
+  '';
+in
 {
   name = "RustTools";
   version = "1.0";
@@ -14,16 +23,14 @@
   replit.runners.cargo = {
     name = "cargo run";
     language = "rust";
-    extensions = [".rs"];
     
-    start = "${pkgs.cargo}/bin/cargo run";
+    start = "${cargoRun}/bin/cargo_run";
     fileParam = false;
   };
 
   replit.languageServers.rust-analyzer = {
     name = "rust-analyzer";
     language = "rust";
-    extensions = [".rs"];
     
     start = "${pkgs.rust-analyzer}/bin/rust-analyzer";
   };
@@ -31,7 +38,6 @@
   replit.formatters.cargo-fmt = {
     name = "cargo fmt";
     language = "rust";
-    extensions = [".rs"];
 
     start = "${pkgs.cargo}/bin/cargo fmt";
     stdin = false;
@@ -40,7 +46,6 @@
   replit.formatters.rustfmt = {
     name = "rustfmt";
     language = "rust";
-    extensions = [".rs"];
 
     start = "${pkgs.rustfmt}/bin/rustfmt $file";
     stdin = false;


### PR DESCRIPTION
## Why?

Some tweaks to the rust and go modules to prep them for being used in the prod templates.

## Changes

1. In go, just use `go run $file` with fileParam in lieu of `go build` and then running the binary
2. In rust, have a shell script auto check for `Cargo.toml` file and run `cargo init` if not exists