### PR TITLE
Set default 

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-default=nixpkgs-unstable
+default=nixpkgs-22.11
 channel=$default
 
 ignore=`cat .gitignore | xargs printf -- '--exclude=%s\n'`


### PR DESCRIPTION
## Why

I set the default channel in default.nix to 22.11, but that broke the build.sh script and caused all channels to be 22.11. This broke Pygame in Canary.

## Change

Updated the default channel in the build script.

## Testing

Deploy cacache disk again, and see that each channel correctly references its own code. See that Pygame is fixed.