### PR TITLE
Change compile default to null

### DIFF
--- a/pkgs/moduleit/module-definition.nix
+++ b/pkgs/moduleit/module-definition.nix
@@ -128,7 +128,7 @@ let
 
       compile = mkOption {
         type = types.nullOr commandType;
-        default = "";
+        default = null;
         description = lib.mdDoc ''
           The command to compile a source file. Use $file to substitute in the file path.
         '';
@@ -255,7 +255,6 @@ let
 
       start = mkOption {
         type = commandType;
-        default = "";
         description = lib.mdDoc ''
           The command to start the debug (dap) server.
         '';


### PR DESCRIPTION
## Why?

Compile option was mistakenly set to default to the empty string and run.go actually executed the empty command, which although did nothing, caused `sh -c` to be displayed in the console.

![Screenshot from 2023-03-22 13-51-50](https://user-images.githubusercontent.com/54303/226994187-f47d2eff-dc02-42d9-890c-95ae1afa3931.png)

## Change

1. Changed its default to null
2. Removed the start default from the debugger. This should be required.

## Test

1. If you compile a module without a compile option, its value in the compile output should be null, not `""`