### PR TITLE
Remove out link before a nix build.

### DIFF
--- a/pkgs/moduleit/moduleit.sh
+++ b/pkgs/moduleit/moduleit.sh
@@ -14,6 +14,10 @@ args=("$ENTRYPOINT_PATH" --argstr configPath "$MODULE_FILE_ABSOLUTE_PATH")
 
 if [ ! -z "${OUT_LINK}" ]; then
   args+=(--out-link "${OUT_LINK}")
+
+  if [[ -f "${OUT_LINK}" ]]; then
+    rm -f "${OUT_LINK}"
+  fi
 fi
 
 echo "nix-build ${args[@]}"

--- a/pkgs/moduleit/moduleit.sh
+++ b/pkgs/moduleit/moduleit.sh
@@ -4,7 +4,7 @@ if [ $# -eq 0 ]; then
 fi
 
 MODULE_FILE="$1"
-OUT_LINK="$2"
+OUTPUT_FILE="$2"
 
 MODULE_FILE_ABSOLUTE_PATH="$(realpath $MODULE_FILE)"
 SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
@@ -12,20 +12,20 @@ ENTRYPOINT_PATH="$SCRIPT_DIR/entrypoint.nix"
 
 args=("$ENTRYPOINT_PATH" --argstr configPath "$MODULE_FILE_ABSOLUTE_PATH")
 
-if [ ! -z "${OUT_LINK}" ]; then
-  args+=(--out-link "${OUT_LINK}")
+if [ ! -z "${OUTPUT_FILE}" ]; then
+  args+=(--out-link "${OUTPUT_FILE}")
 
-  if [[ -f "${OUT_LINK}" ]]; then
-    rm -f "${OUT_LINK}"
+  if [[ -f "${OUTPUT_FILE}" ]]; then
+    rm -f "${OUTPUT_FILE}"
   fi
 fi
 
 echo "nix-build ${args[@]}"
 nix-build "${args[@]}"
 
-if [ -L "${OUT_LINK}" ]; then
+if [ -L "${OUTPUT_FILE}" ]; then
   # If output link was provided,
   # materialize the output as an actual file containing the JSON config
   # instead of a symlink
-  cp --remove-destination "$(realpath "${OUT_LINK}")" "${OUT_LINK}"
+  cp --remove-destination "$(realpath "${OUTPUT_FILE}")" "${OUTPUT_FILE}"
 fi


### PR DESCRIPTION
## Why?

When an input module .nix is rebuild, moduleit actually fails because it cannot overwrite the already existing out link:

![Screenshot from 2023-03-22 14-46-27](https://user-images.githubusercontent.com/54303/227006584-33bcc7ec-be09-4807-9acf-b6715a766d63.png)

## Changes

1. Added a statement to remove the out link file
2. Renamed OUT_LINK to OUTPUT_FILE, which is more correct because we materialize into a file, not a symlink anymore

## Testing

1. `cd pkgs/moduleit`
2. `./moduleit.sh example.nix blargh`
3. `./moduleit.sh example.nix blargh` this should not fail.