### PR TITLE
Added productionOverride option for runners

### DIFF
--- a/pkgs/moduleit/example.nix
+++ b/pkgs/moduleit/example.nix
@@ -41,6 +41,12 @@ in
         };
       };
       fileParam = true;
+      productionOverride = {
+        # only the options below
+        start = "pm2 start server.js";
+        compile = "yarn build";
+        fileParam = false;
+      };
     };
 
     debuggers.nodeDAP = {

--- a/pkgs/moduleit/module-definition.nix
+++ b/pkgs/moduleit/module-definition.nix
@@ -128,7 +128,7 @@ let
 
       compile = mkOption {
         type = types.nullOr commandType;
-        default = "";
+        default = null;
         description = lib.mdDoc ''
           The command to compile a source file. Use $file to substitute in the file path.
         '';
@@ -255,7 +255,6 @@ let
 
       start = mkOption {
         type = commandType;
-        default = "";
         description = lib.mdDoc ''
           The command to start the debug (dap) server.
         '';

--- a/pkgs/moduleit/module-definition.nix
+++ b/pkgs/moduleit/module-definition.nix
@@ -80,7 +80,35 @@ let
     };
   };
 
-  runnerModule = { name, config, ... }: {
+  runnerModule = { name, config, ... }: 
+    let runnerProductionOverrides = { name, config, ... }:
+      {
+        options = {
+          start = mkOption {
+            type = commandType;
+            description = lib.mdDoc ''
+              The command to run a file in production. Use $file to substitute in the file path.
+            '';
+          };
+
+          compile = mkOption {
+            type = types.nullOr commandType;
+            default = null;
+            description = lib.mdDoc ''
+              The command to compile a source file in production. Use $file to substitute in the file path.
+            '';
+          };
+
+          fileParam = mkOption {
+            type = types.bool;
+            description = lib.mdDoc ''
+              Whether this runner accepts a $file paramater in production.
+            '';
+          };
+        };
+      };
+    in
+    {
     options = {
       name = mkOption {
         type = types.str;
@@ -131,6 +159,15 @@ let
         default = null;
         description = lib.mdDoc ''
           The command to compile a source file. Use $file to substitute in the file path.
+        '';
+      };
+
+      productionOverride = mkOption {
+        type = types.nullOr (types.submodule runnerProductionOverrides);
+        default = null;
+        description = lib.mdDoc ''
+          The command configurations to use in production overriding the normal commands
+          that are used in development.
         '';
       };
 

--- a/pkgs/moduleit/module-definition.nix
+++ b/pkgs/moduleit/module-definition.nix
@@ -102,6 +102,7 @@ let
 
             fileParam = mkOption {
               type = types.bool;
+              default = false;
               description = lib.mdDoc ''
                 Whether this runner accepts a $file paramater in production.
               '';
@@ -134,6 +135,7 @@ let
 
         fileParam = mkOption {
           type = types.bool;
+          default = false;
           description = lib.mdDoc ''
             Whether this runner accepts a $file paramater.
           '';
@@ -300,6 +302,7 @@ let
 
       fileParam = mkOption {
         type = types.bool;
+        default = false;
         description = lib.mdDoc ''
           Whether this debugger accepts a $file paramater.
         '';

--- a/pkgs/moduleit/module-definition.nix
+++ b/pkgs/moduleit/module-definition.nix
@@ -80,99 +80,100 @@ let
     };
   };
 
-  runnerModule = { name, config, ... }: 
-    let runnerProductionOverrides = { name, config, ... }:
-      {
-        options = {
-          start = mkOption {
-            type = commandType;
-            description = lib.mdDoc ''
-              The command to run a file in production. Use $file to substitute in the file path.
-            '';
-          };
+  runnerModule = { name, config, ... }:
+    let
+      runnerProductionOverrides = { name, config, ... }:
+        {
+          options = {
+            start = mkOption {
+              type = commandType;
+              description = lib.mdDoc ''
+                The command to run a file in production. Use $file to substitute in the file path.
+              '';
+            };
 
-          compile = mkOption {
-            type = types.nullOr commandType;
-            default = null;
-            description = lib.mdDoc ''
-              The command to compile a source file in production. Use $file to substitute in the file path.
-            '';
-          };
+            compile = mkOption {
+              type = types.nullOr commandType;
+              default = null;
+              description = lib.mdDoc ''
+                The command to compile a source file in production. Use $file to substitute in the file path.
+              '';
+            };
 
-          fileParam = mkOption {
-            type = types.bool;
-            description = lib.mdDoc ''
-              Whether this runner accepts a $file paramater in production.
-            '';
+            fileParam = mkOption {
+              type = types.bool;
+              description = lib.mdDoc ''
+                Whether this runner accepts a $file paramater in production.
+              '';
+            };
           };
         };
-      };
     in
     {
-    options = {
-      name = mkOption {
-        type = types.str;
-        description = lib.mdDoc ''
-          The name of the runner.
-        '';
-      };
+      options = {
+        name = mkOption {
+          type = types.str;
+          description = lib.mdDoc ''
+            The name of the runner.
+          '';
+        };
 
-      language = mkOption {
-        type = types.str;
-        description = lib.mdDoc ''
-          The language this runner supports.
-        '';
-      };
+        language = mkOption {
+          type = types.str;
+          description = lib.mdDoc ''
+            The language this runner supports.
+          '';
+        };
 
-      start = mkOption {
-        type = commandType;
-        description = lib.mdDoc ''
-          The command to run a file. Use $file to substitute in the file path.
-        '';
-      };
+        start = mkOption {
+          type = commandType;
+          description = lib.mdDoc ''
+            The command to run a file. Use $file to substitute in the file path.
+          '';
+        };
 
-      fileParam = mkOption {
-        type = types.bool;
-        description = lib.mdDoc ''
-          Whether this runner accepts a $file paramater.
-        '';
-      };
+        fileParam = mkOption {
+          type = types.bool;
+          description = lib.mdDoc ''
+            Whether this runner accepts a $file paramater.
+          '';
+        };
 
-      interpreter = mkOption {
-        type = types.bool;
-        default = false;
-        description = lib.mdDoc ''
-          Whether this runner starts an interpreter. Default: false.
-        '';
-      };
+        interpreter = mkOption {
+          type = types.bool;
+          default = false;
+          description = lib.mdDoc ''
+            Whether this runner starts an interpreter. Default: false.
+          '';
+        };
 
-      prompt = mkOption {
-        type = types.str;
-        default = "";
-        description = lib.mdDoc ''
-          If interpreter is true, this prompt is displayed.
-        '';
-      };
+        prompt = mkOption {
+          type = types.str;
+          default = "";
+          description = lib.mdDoc ''
+            If interpreter is true, this prompt is displayed.
+          '';
+        };
 
-      compile = mkOption {
-        type = types.nullOr commandType;
-        default = null;
-        description = lib.mdDoc ''
-          The command to compile a source file. Use $file to substitute in the file path.
-        '';
-      };
+        compile = mkOption {
+          type = types.nullOr commandType;
+          default = null;
+          description = lib.mdDoc ''
+            The command to compile a source file. Use $file to substitute in the file path.
+          '';
+        };
 
-      productionOverride = mkOption {
-        type = types.nullOr (types.submodule runnerProductionOverrides);
-        default = null;
-        description = lib.mdDoc ''
-          The command configurations to use in production overriding the normal commands
-          that are used in development.
-        '';
-      };
+        productionOverride = mkOption {
+          type = types.nullOr (types.submodule runnerProductionOverrides);
+          default = null;
+          description = lib.mdDoc ''
+            The command configurations to use in production overriding the normal commands
+            that are used in development.
+          '';
+        };
 
-    } // fileTypeAttrs;
-  };
+      } // fileTypeAttrs;
+    };
 
   languageServerModule = { name, config, ... }: {
     options = {


### PR DESCRIPTION
## Why?

For deployments feature, we'd like to have commands overrides for a runner in production. Context: https://replit.slack.com/archives/C03KS2B221W/p1678830363884739?thread_ts=1678827326.655739&cid=C03KS2B221W

## Changes

Added the productionOverride option.

## Testing

1. `cd pkgs/moduleit`
2. `./moduleit.sh example.nix`
3. `cat result|jq` - see productionOverride options are included