### PR TITLE
Fix PATH issues with swiftc and use swift to run directly in dev

### DIFF
--- a/modules/swift.nix
+++ b/modules/swift.nix
@@ -1,15 +1,14 @@
 { pkgs, ... }:
 let swiftc-wrapper = pkgs.stdenv.mkDerivation {
   name = "swiftc-wrapper";
-  buildInputs = [pkgs.makeWrapper pkgs.swift];
+  buildInputs = [pkgs.makeWrapper];
   src = ./.;
 
+  
   installPhase = ''
     mkdir -p $out/bin
     makeWrapper ${pkgs.swift}/bin/swiftc $out/bin/swiftc \
-      --set PATH ${pkgs.lib.makeBinPath [
-        pkgs.swift
-      ]}
+      --set PATH ""
   '';
 };
 in

--- a/modules/swift.nix
+++ b/modules/swift.nix
@@ -19,6 +19,7 @@ in
 
   packages = with pkgs; [
     swiftc-wrapper
+    swift
   ];
 
   replit.runners.swift = {


### PR DESCRIPTION
## Why?

When installing swift to a repl. Compile + run fails if the .replit doesn't have Nix channel 22.11 specified because a different version of binutils is getting picked up by swiftc.

## Changes

1. Use swift directly to run a .swift program
2. For compiling swiftc, we create a wrapper program that freezes the PATH variable for that invocation of swiftc

## Testing

1. `nix-build -A replitPackages.modules`
2. Play with in at https://replit.com/@util/NixModulesExamples#swift.nix