### PR TITLE
Add packager capability to rust

### DIFF
--- a/modules/rust.nix
+++ b/modules/rust.nix
@@ -56,6 +56,8 @@ in
     language = "rust";
     features = {
       packageSearch = true;
+      guessImports = false;
+      enabledForHosting = false;
     };
   };
 }

--- a/modules/rust.nix
+++ b/modules/rust.nix
@@ -50,4 +50,12 @@ in
     start = "${pkgs.rustfmt}/bin/rustfmt $file";
     stdin = false;
   };
+
+  replit.packagers.rust = {
+    name = "Rust";
+    language = "rust";
+    features = {
+      packageSearch = true;
+    };
+  };
 }


### PR DESCRIPTION
We have upm for rust that handles search and adding/removing packages.

Added rust packager.

### Test plan

I'm unable to test this properly, I went to https://replit.com/@util/NixModulesExamples and I made the changes to rust.nix, i built it with `moduleit` but don't see the packager sidebar, maybe there's a bug with feature detection in the workspace or something.