### PR TITLE
add bun

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -36,6 +36,8 @@ rec {
 
   jdt-language-server = self.callPackage ./pkgs/jdt-language-server { };
 
+  bun = self.callPackage ./pkgs/bun {};
+
   replitPackages = {
     # Version string set when building overlay
     version = "GIT_SHA_HERE";
@@ -86,8 +88,6 @@ rec {
         go = mkModule ./modules/go.nix;
         swift = mkModule ./modules/swift.nix;
       };
-
-    bun-0_5 = self.callPackage ./pkgs/bun {};
   };
 }
 

--- a/overlay.nix
+++ b/overlay.nix
@@ -87,6 +87,7 @@ rec {
         swift = mkModule ./modules/swift.nix;
       };
 
+    bun-0_5 = self.callPackage ./pkgs/bun {};
   };
 }
 

--- a/overlay.nix
+++ b/overlay.nix
@@ -36,7 +36,7 @@ rec {
 
   jdt-language-server = self.callPackage ./pkgs/jdt-language-server { };
 
-  bun = self.callPackage ./pkgs/bun {};
+  bun = self.callPackage ./pkgs/bun { };
 
   replitPackages = {
     # Version string set when building overlay

--- a/pkgs/bun/default.nix
+++ b/pkgs/bun/default.nix
@@ -1,0 +1,35 @@
+{ lib
+, stdenvNoCC
+, callPackage
+, fetchurl
+, autoPatchelfHook
+, unzip
+, openssl
+, writeShellScript
+, curl
+, jq
+, common-updater-scripts
+}:
+
+stdenvNoCC.mkDerivation rec {
+  version = "0.5.8";
+  pname = "bun";
+
+  src = fetchurl {
+    url = "https://github.com/oven-sh/bun/releases/download/bun-v0.5.8/bun-linux-x64.zip";
+    sha256 = "1khbhbks3vs6kj9rh8132gwmg1ps3grbanw54gnn610hqns9kn7q";
+  };
+
+  strictDeps = true;
+  nativeBuildInputs = [ unzip ] ++ lib.optionals stdenvNoCC.isLinux [ autoPatchelfHook ];
+  buildInputs = [ openssl ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm 755 ./bun $out/bin/bun
+    runHook postInstall
+  '';
+}


### PR DESCRIPTION
Seems that bun greatly outperforms npm and yarn on replit, and we'd like to support it. This adds bun 0.5.8 to our overlay since the [current version in nixpkgs](https://search.nixos.org/packages?channel=22.11&show=bun) is 0.2 (which doesn't support git dependencies) and doesn't exist in our frozen nixpkgs

- [slack thread](https://search.nixos.org/packages?channel=22.11&show=bun)
- to show that there's demand for bun, [there's a template for it](https://replit.com/@bddy/Bun-Template)