### PR TITLE
bun -> replitPackages.bun

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -5,7 +5,7 @@
 }:
 let
   overlay = (import ./overlay.nix) {
-    inherit sources;
+    inherit sources channelName;
   };
 in
 import channel { inherit system; overlays = [ overlay ]; }

--- a/overlay.nix
+++ b/overlay.nix
@@ -36,8 +36,6 @@ rec {
 
   jdt-language-server = self.callPackage ./pkgs/jdt-language-server { };
 
-  bun = self.callPackage ./pkgs/bun { };
-
   replitPackages = {
     # Version string set when building overlay
     version = "GIT_SHA_HERE";
@@ -88,6 +86,8 @@ rec {
         go = mkModule ./modules/go.nix;
         swift = mkModule ./modules/swift.nix;
       };
+
+    bun = self.callPackage ./pkgs/bun { };
   };
 }
 

--- a/overlay.nix
+++ b/overlay.nix
@@ -1,6 +1,5 @@
-{ sources }:
+{ channelName, sources }:
 self: super:
-with super.lib;
 let
   privateNodePackages = self.callPackage ./pkgs/node-packages {
     nodejs = super."nodejs-14_x";
@@ -87,7 +86,7 @@ rec {
         swift = mkModule ./modules/swift.nix;
       };
 
-    bun = self.callPackage ./pkgs/bun { };
+    bun = self.lib.mkIf (channelName != "nixpkgs-legacy") (self.callPackage ./pkgs/bun { });
   };
 }
 

--- a/overlay.nix
+++ b/overlay.nix
@@ -86,7 +86,10 @@ rec {
         swift = mkModule ./modules/swift.nix;
       };
 
-    bun = self.lib.mkIf (channelName != "nixpkgs-legacy") (self.callPackage ./pkgs/bun { });
+    bun =
+      if channelName != "nixpkgs-legacy"
+      then self.callPackage ./pkgs/bun { }
+      else null;
   };
 }
 

--- a/pkgs/bun/default.nix
+++ b/pkgs/bun/default.nix
@@ -11,13 +11,13 @@
 , common-updater-scripts
 }:
 
-stdenvNoCC.mkDerivation rec {
-  version = "0.5.8";
+stdenvNoCC.mkDerivation {
+  version = "0.5.9";
   pname = "bun";
 
   src = fetchurl {
-    url = "https://github.com/oven-sh/bun/releases/download/bun-v0.5.8/bun-linux-x64.zip";
-    sha256 = "1khbhbks3vs6kj9rh8132gwmg1ps3grbanw54gnn610hqns9kn7q";
+    url = "https://github.com/oven-sh/bun/releases/download/bun-v0.5.9/bun-linux-x64.zip";
+    sha256 = "vwxkydYJdnb8MBUAfywpXdaahsuw5IvnXeoUmilzruE=";
   };
 
   strictDeps = true;


### PR DESCRIPTION
As mentioned offline, it makes more sense to add our `bun` package to `replitPackages` than be at the top-level, to allow for version freezing. 