### PR TITLE
update module name attributes for consistency

### DIFF
--- a/modules/go.nix
+++ b/modules/go.nix
@@ -1,6 +1,6 @@
 { pkgs, ... }:
 {
-  name = "GoTools";
+  name = "Go Tools";
   version = "1.0";
 
   packages = with pkgs; [

--- a/modules/rust.nix
+++ b/modules/rust.nix
@@ -9,7 +9,7 @@ let cargoRun = pkgs.writeScriptBin "cargo_run" ''
   '';
 in
 {
-  name = "RustTools";
+  name = "Rust Tools";
   version = "1.0";
 
   packages = with pkgs; [

--- a/modules/swift.nix
+++ b/modules/swift.nix
@@ -13,7 +13,7 @@ let swiftc-wrapper = pkgs.stdenv.mkDerivation {
 };
 in
  {
-  name = "SwiftTools";
+  name = "Swift Tools";
   version = "1.0";
 
   packages = with pkgs; [


### PR DESCRIPTION
it's confusing to have `RustTools` but `Go Tools`. This fixes that