### PR TITLE
bump nixpkgs-unstable

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -64,10 +64,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b01f185e4866de7c5b5a82f833ca9ea3c3f72fc4",
-        "sha256": "02sdwkxa3gw582lykfvvki2gk501kda7vqy4q3mcrk8k5ppbk1b3",
+        "rev": "0a4206a51b386e5cda731e8ac78d76ad924c7125",
+        "sha256": "0gjlg8gwsgfm3gzwg5mzg4nh8lhlid18ls6barvahllbjp6sdc9j",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/b01f185e4866de7c5b5a82f833ca9ea3c3f72fc4.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/0a4206a51b386e5cda731e8ac78d76ad924c7125.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "prybar": {


### PR DESCRIPTION
Why
​====
Per #96 we should update unstable more.

What changed
​============
* Ran `niv update nixpkgs-unstable`

Test plan
​=======
* CI passes