### PR TITLE
checkout code before deploying to spinnaker

### DIFF
--- a/.semaphore/push.yml
+++ b/.semaphore/push.yml
@@ -38,4 +38,5 @@ blocks:
       jobs:
         - name: Notify spinnaker
           commands:
+            - checkout
             - ./spin_deploy.sh


### PR DESCRIPTION
Deployments to spinnaker aren't working [due to a missing `spin_deploy.sh` file](https://replit.semaphoreci.com/jobs/6e48f9fd-b159-4fcf-bc7a-8a65160a7aae). The file exists in the repository, the issue is that we don't checkout the repository before calling the script. This adds `checkout` as a command to run before calling said script

Test plan is to just run the deployment; if it works, we're all set!