### PR TITLE
use double quotes to get semaphore git sha

### DIFF
--- a/spin_deploy.sh
+++ b/spin_deploy.sh
@@ -7,7 +7,7 @@ cache restore "nixpkgs-last-successful-sha"
 LAST_SHA=$(cat "nixpkgs-last-successful-sha" || echo "$SEMAPHORE_GIT_SHA")
 SHA_SHORT=$(git rev-parse --short=8 "$SEMAPHORE_GIT_SHA")
 AUTHOR_EMAIL=$(git show -s --format='%ae' "$SEMAPHORE_GIT_SHA")
-ALL_AUTHORS=$(git log  --format="%ae" $LAST_SHA..$SEMAPHORE_GIT_SHA | sort | uniq | paste -sd "," -)
+ALL_AUTHORS=$(git log  --format="%ae" "$LAST_SHA".."$SEMAPHORE_GIT_SHA" | sort | uniq | paste -sd "," -)
 
 cat <<EOF >payload.json
 {
@@ -32,8 +32,8 @@ curl --fail -X POST \
   -H "WEBHOOK_AUTH" \
   -H "content-type: application/json" \
   -d @payload.json \
-    $WEBHOOK_URL
+    "$WEBHOOK_URL"
 
-git rev-parse --verify $SEMAPHORE_GIT_SHA >"nixpkgs-last-successful-sha"
+git rev-parse --verify "$SEMAPHORE_GIT_SHA" >"nixpkgs-last-successful-sha"
 cache delete "nixpkgs-last-successful-sha"
 cache store "nixpkgs-last-successful-sha" "nixpkgs-last-successful-sha"

--- a/spin_deploy.sh
+++ b/spin_deploy.sh
@@ -4,7 +4,7 @@ set -evxo pipefail
 
 cache restore "nixpkgs-last-successful-sha"
 
-LAST_SHA=$(cat "nixpkgs-last-successful-sha" || echo '$SEMAPHORE_GIT_SHA')
+LAST_SHA=$(cat "nixpkgs-last-successful-sha" || echo "$SEMAPHORE_GIT_SHA")
 SHA_SHORT=$(git rev-parse --short=8 "$SEMAPHORE_GIT_SHA")
 AUTHOR_EMAIL=$(git show -s --format='%ae' "$SEMAPHORE_GIT_SHA")
 ALL_AUTHORS=$(git log  --format="%ae" $LAST_SHA..$SEMAPHORE_GIT_SHA | sort | uniq | paste -sd "," -)


### PR DESCRIPTION
followup of #122 and #121 - getting the last successful git sha in semaphore [breaks the deploy script](https://replit.semaphoreci.com/jobs/9ff72998-05fe-4a9c-877f-3fc5aecb5198). I've updated `spin_deploy.sh` to use `"$SEMAPHORE_GIT_SHA"` instead of `'$SEMAPHORE_GIT_SHA'` to rectify this.

Same as before, the test is a successful deploy