### PR TITLE
fix POST header in spin_deploy.sh

### DIFF
--- a/spin_deploy.sh
+++ b/spin_deploy.sh
@@ -22,7 +22,7 @@ cat <<EOF >payload.json
       "last_author": "$AUTHOR_EMAIL",
       "all_authors": "$ALL_AUTHORS",
       "rollback_pipeline": "webhooks/webhook/nixpkgs-replit-rollback",
-      "scratch": "false",
+      "scratch": "false"
     }
   }
 }


### PR DESCRIPTION
follow up on #121, #122, and #123

the POST request for the Spinnaker webhook [failed due to a bad header](https://replit.semaphoreci.com/jobs/722c7486-d015-44f2-8572-457308dc6d3d). This fixes a variable interpolation in `spin_deploy.sh`.

Note that the value of the variable is defined in Semaphore as a secret; it's not defined in the repository