### PR TITLE
Configure pip and poetry out of the box

### DIFF
--- a/modules/python.nix
+++ b/modules/python.nix
@@ -146,7 +146,7 @@ in
     name = "Python";
     language = "python3";
     ignoredPackages = [ "unit_tests" ];
-    ignoredPaths = [".pythonlibs"]; 
+    ignoredPaths = [ ".pythonlibs" ];
     features = {
       packageSearch = true;
       guessImports = true;

--- a/modules/python.nix
+++ b/modules/python.nix
@@ -2,7 +2,32 @@
 let
   pip = pkgs.callPackage ../pkgs/pip { };
 
+  pip-config = pkgs.writeTextFile {
+    name = "pip.conf";
+    text = ''
+      [global]
+      user = yes
+      disable-pip-version-check = yes
+      index-url = https://package-proxy.replit.com/pypi/simple/
+      
+      [install]
+      use-feature = content-addressable-pool
+      content-addressable-pool-symlink = yes
+    '';
+  };
+
   poetry = pkgs.callPackage ../pkgs/poetry { };
+
+  poetry-config = pkgs.writeTextFile {
+    name = "poetry-config";
+    text = ''
+      [[tool.poetry.source]]
+      name = "replit"
+      url = "https://package-proxy.replit.com/pypi/simple/"
+      default = true
+    '';
+    destination = "/conf.toml";
+  };
 
   python = pkgs.python310Full;
 
@@ -121,6 +146,7 @@ in
     name = "Python";
     language = "python3";
     ignoredPackages = [ "unit_tests" ];
+    ignoredPaths = [".pythonlibs"]; 
     features = {
       packageSearch = true;
       guessImports = true;
@@ -132,7 +158,8 @@ in
     let userbase = "$HOME/$REPL_SLUG/.pythonlibs";
     in {
       PYTHONPATH = "${userbase}/${python.sitePackages}";
-      PIP_USER = "1";
+      PIP_CONFIG_FILE = pip-config.outPath;
+      POETRY_CONFIG_DIR = poetry-config.outPath;
       POETRY_VIRTUALENVS_CREATE = "0";
       PYTHONUSERBASE = userbase;
     };


### PR DESCRIPTION
## Why?

Even with our poetry and pip being delivered from nix, they still have to be configured correctly to work with cacache.
Found these fixes after testing the python module in [this repl](https://replit.com/@tobyho/HorribleMagentaJavadocs#main.py).

## Changes

1. added a pip config file
2. added a poetry config file
3. configured packager to ignore the `.pythonlibs` directory: where the libs are installed#126 

## Testing

You can test in [this repl](https://replit.com/join/paqzsmgeut-tobyho)

1. Use the packager to install a package, see that the package ends up in `.pythonlibs/lib/python3.10/site-packages/`
2. Check that the files within the packages are symlinks, example: `ls -l .pythonlibs/lib/python3.10/site-packages/requests`
3. Remove an installed package, see that the files are gone from `.pythonlibs/lib/python3.10/site-packages/`
4. See that packaging guessing works `import yaml` should end up installing pyyaml