### PR TITLE
Add formatting capability to css in web.nix module

### DIFF
--- a/modules/web.nix
+++ b/modules/web.nix
@@ -70,6 +70,10 @@
 
     start = "${pkgs.nodePackages.vscode-langservers-extracted}/bin/vscode-css-language-server --stdio";
 
+    initializationOptions = {
+      provideFormatter = true;
+    };
+
     configuration =
       let
         config = {


### PR DESCRIPTION
Not much to it. We just applied this to our html template

the option comes from:  https://github.com/microsoft/vscode/blob/main/extensions/css-language-features/server/src/cssServer.ts#L132-L133