### PR TITLE
Node DAP temp fix: use dap-node from pid1 bundle

### DIFF
--- a/modules/nodejs.nix
+++ b/modules/nodejs.nix
@@ -6,8 +6,6 @@ let
 
   prybar = pkgs.replitPackages.prybar-nodejs;
 
-  dap-node = pkgs.callPackage ../pkgs/dapNode { };
-
   run-prybar = pkgs.writeShellScriptBin "run-prybar" ''
     ${prybar}/bin/prybar-nodejs -q --ps1 "''$(printf '\u0001\u001b[33m\u0002\u0001\u001b[00m\u0002 ')" -i ''$1
   '';
@@ -45,7 +43,9 @@ in
       language = "javascript";
       transport = "localhost:0";
       fileParam = true;
-      start = "${dap-node}/bin/dap-node";
+      start = {
+        args = ["dap-node"];
+      };
       initializeMessage = {
         command = "initialize";
         type = "request";

--- a/modules/nodejs.nix
+++ b/modules/nodejs.nix
@@ -44,7 +44,7 @@ in
       transport = "localhost:0";
       fileParam = true;
       start = {
-        args = ["dap-node"];
+        args = [ "dap-node" ];
       };
       initializeMessage = {
         command = "initialize";


### PR DESCRIPTION
## Why?

Currently if you try to use the debugger from the nodejs module, there are a couple of glaring bugs:

1. when you start the debugger, webview shows up because it detected the debugger opening a port
2. when viewing the variables in the debugger, if you click "see more", a massive amount of overlapping text overfills the debugger panel

I had previously spent a considerable amount of time on DAP for Node. But since we are shortening the time frame for delivering Nix modules, let's punt on this and use the existing `dap-node` delivered from the pid1 bundle.

## Changes

Use the dap-node executable from the environment, which should be delivered out of the pid1 bundle.

## Testing

Setup the `nodejs.nix` in a repl and use moduleit to build it. Then create a `.js` file an use the debugger on it.

Here's a repl that already has it setup: https://replit.com/join/drzhamstph-tobyho