### PR TITLE
Revert "Update nixpkgs-unstable"

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -64,10 +64,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f2e9a130461950270f87630b11132323706b4d91",
-        "sha256": "05qz5q9igl3095wncj493kkqdpdl2qahycbsz77dhh7rfy16n5cg",
+        "rev": "b01f185e4866de7c5b5a82f833ca9ea3c3f72fc4",
+        "sha256": "02sdwkxa3gw582lykfvvki2gk501kda7vqy4q3mcrk8k5ppbk1b3",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/f2e9a130461950270f87630b11132323706b4d91.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/b01f185e4866de7c5b5a82f833ca9ea3c3f72fc4.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "prybar": {


### PR DESCRIPTION
Reverts replit/nixpkgs-replit#133

We need to revert this because of problems with nodejs caching and nix 2.3. We can work around this ourselves but maybe upstream will accept this revert quickly.

https://github.com/NixOS/nixpkgs/pull/229538

More context: https://replit.slack.com/archives/C03KS2B221W/p1683049536504389?thread_ts=1682957718.410959&cid=C03KS2B221W