### PR TITLE
fix build.sh

### DIFF
--- a/.semaphore/push.yml
+++ b/.semaphore/push.yml
@@ -28,7 +28,7 @@ blocks:
                 - nixpkgs-23.05
                 - nixpkgs-unstable
           commands:
-            - sh build.sh $NIXPKGS_CHANNEL
+            - ./build.sh $NIXPKGS_CHANNEL
             - gsutil cp $NIXPKGS_CHANNEL.tar.gz gs://replit-nixpkgs/$NIXPKGS_CHANNEL.tar.gz
             - gsutil acl ch -u AllUsers:R gs://replit-nixpkgs/$NIXPKGS_CHANNEL.tar.gz
 

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -54,7 +54,7 @@ blocks:
                 - nixpkgs-unstable
           commands:
             - mkdir /tmp/$NIXPKGS_CHANNEL
-            - sh build.sh $NIXPKGS_CHANNEL
+            - ./build.sh $NIXPKGS_CHANNEL
             - tar -xvf $NIXPKGS_CHANNEL.tar.gz -C /tmp/$NIXPKGS_CHANNEL
             - nix-build /tmp/$NIXPKGS_CHANNEL/nixpkgs/default.nix -A replitPackages
 

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,12 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
-default=nixpkgs-22.11
+default=nixpkgs-23.05
 channel=$default
+
+function error() {
+    echo $1
+    exit 1
+}
 
 ignore=`cat .gitignore | xargs printf -- '--exclude=%s\n'`
 
@@ -13,6 +18,7 @@ echo "Building tarball for $channel"
 
 # Update default.nix to use the specified nix package
 sed -i s/\"$default\"/\"$channel\"/g default.nix
+grep $channel default.nix || error "${channel} not properly subsituted into default.nix"
 
 # Update default.nix to use the specified nix package
 sha=`git rev-parse --verify HEAD`


### PR DESCRIPTION
Why
===
* When build.sh built the tarball, it left the channelName as nixpkgs-23.05 instead of changing it to older channelNames (for example nixpkgs 22.11)

What changed
===
* update the default to match
* add check to make sure expected substitution happens (otherwise fail to build channel)

Test plan
===
* ran build.sh and confirmed the tarball has the correct default.nix channelName