### PR TITLE
stop maintaining overlay for nixpkgs 23.05

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -1,5 +1,8 @@
 { channelName, sources }:
 self: super:
+
+if channelName == "nixpkgs-23.05" then { replitPackages = { }; } else
+
 let
   privateNodePackages = self.callPackage ./pkgs/node-packages {
     nodejs = super."nodejs-14_x";


### PR DESCRIPTION
Why
===
* There are various things in the overlay that are not buidling.
* We're migrating to using https://github.com/replit/nixmodules/ for our Nix work, so we will not need to bump the templates to 23.05 until after they're converted to nixmodules

What changed
===
* If the channel is nixpkgs-23.05
  * make the replitPackages overlay empty.
  * Don't augment nodePackages with our typescript-language-server
  * Don't build python310Full differently
  * Don't add jdt-language-server

Test plan
===
* CI finishes
* Make sure old templates work