### PR TITLE
add manual promotions for each channel

### DIFF
--- a/.semaphore/notify-spinnaker.yml
+++ b/.semaphore/notify-spinnaker.yml
@@ -1,0 +1,19 @@
+version: v1.0
+name: deploy
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu2004
+auto_cancel:
+  running:
+    when: branch != 'master'
+blocks:
+  - name: Notify spinnaker
+    task:
+      secrets:
+        - name: replit-nixpkgs-semaphore
+      jobs:
+        - name: Notify spinnaker
+          commands:
+            - checkout
+            - ./spin_deploy.sh

--- a/.semaphore/push.yml
+++ b/.semaphore/push.yml
@@ -18,26 +18,7 @@ blocks:
           - checkout
       jobs:
         - name: Make and upload tarballs
-          matrix:
-            - env_var: NIXPKGS_CHANNEL
-              values:
-                - nixpkgs-legacy
-                - nixpkgs-21.11
-                - nixpkgs-22.05
-                - nixpkgs-22.11
-                - nixpkgs-23.05
-                - nixpkgs-unstable
           commands:
             - ./build.sh $NIXPKGS_CHANNEL
             - gsutil cp $NIXPKGS_CHANNEL.tar.gz gs://replit-nixpkgs/$NIXPKGS_CHANNEL.tar.gz
             - gsutil acl ch -u AllUsers:R gs://replit-nixpkgs/$NIXPKGS_CHANNEL.tar.gz
-
-  - name: Notify spinnaker
-    task:
-      secrets:
-        - name: replit-nixpkgs-semaphore
-      jobs:
-        - name: Notify spinnaker
-          commands:
-            - checkout
-            - ./spin_deploy.sh

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -59,7 +59,59 @@ blocks:
             - nix-build /tmp/$NIXPKGS_CHANNEL/nixpkgs/default.nix -A replitPackages
 
 promotions:
-  - name: Push overlays to GCS
+  - name: Notify Spinnaker
+    pipeline_file: notify-spinnaker.yml
+
+  - name: Push nixpkgs-unstable to GCS
     pipeline_file: push.yml
-    auto_promote:
-      when: "result = 'passed' and branch = 'main'"
+    parameters:
+      env_vars:
+        - required: true
+          default_value: nixpkgs-unstable
+          description: Which channel to update?
+          name: NIXPKGS_CHANNEL
+
+  - name: Push nixpkgs-legacy to GCS
+    pipeline_file: push.yml
+    parameters:
+      env_vars:
+        - required: true
+          default_value: nixpkgs-legacy
+          description: Which channel to update?
+          name: NIXPKGS_CHANNEL
+
+  - name: Push nixpkgs-21.11 to GCS
+    pipeline_file: push.yml
+    parameters:
+      env_vars:
+        - required: true
+          default_value: nixpkgs-21.11
+          description: Which channel to update?
+          name: NIXPKGS_CHANNEL
+
+  - name: Push nixpkgs-22.05 to GCS
+    pipeline_file: push.yml
+    parameters:
+      env_vars:
+        - required: true
+          default_value: nixpkgs-22.05
+          description: Which channel to update?
+          name: NIXPKGS_CHANNEL
+
+  - name: Push nixpkgs-22.11 to GCS
+    pipeline_file: push.yml
+    parameters:
+      env_vars:
+        - required: true
+          default_value: nixpkgs-22.11
+          description: Which channel to update?
+          name: NIXPKGS_CHANNEL
+
+  - name: Push nixpkgs-23.05 to GCS
+    pipeline_file: push.yml
+    parameters:
+      env_vars:
+        - required: true
+          default_value: nixpkgs-23.05
+          description: Which channel to update?
+          name: NIXPKGS_CHANNEL


### PR DESCRIPTION
Why
===
* Updating every channel is not always necessary and is very disruptive to old Repls

What changed
===
* Add a promotion for each channel, so that you have to manually say you want to update it.
* After you've updated as many as you want, you can notify spinnaker to build the disk

Test plan
===
* See that the spinnaker workflow looks correct
* Try promoting one channel
* Roll it back in GCP