### PR TITLE
add gh workflow to update nixpkgs-unstable montly

### DIFF
--- a/.github/workflows/update-unstable.yml
+++ b/.github/workflows/update-unstable.yml
@@ -16,3 +16,8 @@ jobs:
 
       - name: niv update
         run: nix run nixpkgs#niv -- update nixpkgs-unstable
+
+      - name: open PR
+        run: |
+          git commit -am "update nixpkgs-unstable"
+          git push

--- a/.github/workflows/update-unstable.yml
+++ b/.github/workflows/update-unstable.yml
@@ -1,0 +1,18 @@
+name: update unstable
+
+on:
+  schedule:
+    - cron: "0 8 1 * *"
+
+jobs:
+  update-unstable:
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: niv update
+        run: nix run nixpkgs#niv -- update nixpkgs-unstable

--- a/.github/workflows/update-unstable.yml
+++ b/.github/workflows/update-unstable.yml
@@ -2,7 +2,7 @@ name: update unstable
 
 on:
   schedule:
-    - cron: "0 8 20 * *"
+    - cron: "0 17 20 * *"
 
 jobs:
   update-unstable:

--- a/.github/workflows/update-unstable.yml
+++ b/.github/workflows/update-unstable.yml
@@ -2,7 +2,7 @@ name: update unstable
 
 on:
   schedule:
-    - cron: "0 8 1 * *"
+    - cron: "0 8 16 * *"
 
 jobs:
   update-unstable:

--- a/.github/workflows/update-unstable.yml
+++ b/.github/workflows/update-unstable.yml
@@ -2,7 +2,7 @@ name: update unstable
 
 on:
   schedule:
-    - cron: "0 8 16 * *"
+    - cron: "0 8 20 * *"
 
 jobs:
   update-unstable:

--- a/.github/workflows/update-unstable.yml
+++ b/.github/workflows/update-unstable.yml
@@ -18,6 +18,4 @@ jobs:
         run: nix run nixpkgs#niv -- update nixpkgs-unstable
 
       - name: open PR
-        run: |
-          git commit -am "update nixpkgs-unstable"
-          git push
+        uses: peter-evans/create-pull-request@v5


### PR DESCRIPTION
as we decided back in like may, we want to update unstable regularly, or else users will complain

well, users surely complained!

let's prevent that from happening. but we can put up with it for a couple weeks at a time

this adds a gh workflow that runs on the 1st of each month at 0800 (utc i believe) that runs `niv update nixpkgs-unstable`