### PR TITLE
Java Debug send REPL_HOME as root URI and wait for LSP status to be ready

### DIFF
--- a/pkgs/java-debug/java-dap
+++ b/pkgs/java-debug/java-dap
@@ -18,7 +18,7 @@ import sys
 import time
 
 from typing import Any, IO, Dict, List, Mapping, Optional
-
+repl_dir = os.getenv('REPL_HOME')
 
 def _send_lsp_message(msg: Dict[str, Any], lsp: IO[bytes]) -> None:
     """Sends one LSP message."""
@@ -87,11 +87,15 @@ def _run(use_ephemeral_port: bool, language_server: str, debug_plugin: str) -> b
                         },
                         'trace': 'verbose',
                         'capabilities': {},
+                        'rootUri': 'file://' + repl_dir,
                     },
                 }, dap.stdin)
-            # Wait for the initialize message has been acknowledged.
+            # Wait for the initialize message has been acknowledged,
+            # as well as the LSP status to be ready.
             # This maximizes the probability of success.
-            while True:
+            got_reply = False
+            ready = False
+            while not got_reply or not ready:
                 message = _receive_lsp_message(dap.stdout)
                 if not message:
                     return True
@@ -99,7 +103,10 @@ def _run(use_ephemeral_port: bool, language_server: str, debug_plugin: str) -> b
                     print(message.get('params', {}).get('message'),
                           file=sys.stderr)
                 if message.get('id') == 1:
-                    break
+                    got_reply = True
+                if message.get('method') == 'language/status' and \
+                  message.get('params') == {'type': 'Started', 'message': 'Ready'}:
+                    ready = True
             _send_lsp_message(
                 {
                     'id': 2,


### PR DESCRIPTION
# Why

https://github.com/replit/nixpkgs-replit/pull/156 requires that .java files in a project be located in src/main/java per Maven conventions, however, that breaks the Java debugger in that source file locations are not returned when the debugger is paused, which means the IDE is not able to highlight the paused line. This fixes it.

## Changes
1. Java-Debug is implemented as a plugin of JDT language server. So starting it involves:
   a. starting a new instance of JDT language server with java-debug loaded as a plugin
   b. sending JDT an LSP initialization message with the proper activation. We need to send REPL_HOME as the root URI within this message so that JDT can properly import it as a Maven project in order for the source mapping to work.
2. The import of Maven projects happens after the initialization message is acknowledged. So the debugger needs to wait until the LSP's status is ready, at which point, the Maven project(s) would have been imported.

# Testing

1. Make a new Java repl
2. `mkdir -p src/main/java`
3. `mv Main.java src/main/java`
4. check out this repl: `git clone https://github.com/replit/nixpkgs-replit.git`
5. `cd nixpkgs-replit; git checkout th-java-debug-init-with-root-uri`
6. `nix-build --argstr channelName nixpkgs-22.11 -A replitPackages.java-debug`
7. In .replit, under [debugger.interactive], change startCommand to `startCommand = "nixpkgs-replit/result/bin/java-debug"`
8. In .replit under [debugger.compile], change command to `command = "javac -classpath .:target/dependency/* -g -d . $(find src -type f -name '*.java')"`
9. Set a break point in src/main/java/Main.java
10. Open the debugger and hit play
11. See that the could is paused on the line with the breakpoint in the code editor