### PR TITLE
Upgraded channels 23.11 and unstable to get glibc vulnerability

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -65,10 +65,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "7c4c20509c4363195841faa6c911777a134acdf3",
-        "sha256": "1jls78gn9xh0qrbs9jqgsi32nhfgw0zz6hsxvgqyhkffbcw0k4wf",
+        "rev": "b2cf36f43f9ef2ded5711b30b1f393ac423d8f72",
+        "sha256": "07mmgn752nzh8fish8ff5ar9dbdbiv79qb3hl4sazbckqkw38avc",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/7c4c20509c4363195841faa6c911777a134acdf3.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/b2cf36f43f9ef2ded5711b30b1f393ac423d8f72.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs-legacy": {
@@ -88,10 +88,10 @@
         "homepage": "",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "7c4c20509c4363195841faa6c911777a134acdf3",
-        "sha256": "1jls78gn9xh0qrbs9jqgsi32nhfgw0zz6hsxvgqyhkffbcw0k4wf",
+        "rev": "f945939fd679284d736112d3d5410eb867f3b31c",
+        "sha256": "06da1wf4w752spsm16kkckfhxx5m09lwcs8931gwh76yvclq7257",
         "type": "tarball",
-        "url": "https://github.com/nixos/nixpkgs/archive/7c4c20509c4363195841faa6c911777a134acdf3.tar.gz",
+        "url": "https://github.com/nixos/nixpkgs/archive/f945939fd679284d736112d3d5410eb867f3b31c.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "prybar": {


### PR DESCRIPTION
# Why?

1. Get glibc vulnerability fix in
2. Get this upgrade for dotnet that a customer wants

## Changes

1. for 23.11, upgraded to latest
2. for unstable, matched [rev from nixmodules repo](https://github.com/replit/nixmodules/blob/main/flake.lock#L224)

## Test

1. `nix-build --argstr channelName nixpkgs-unstable -A dotnetCorePackages.sdk_8_0` and see `dotnet-sdk-8.0.201`
2. `nix-build --argstr channelName nixpkgs-unstable -A glibc` and see `glibc-2.38-44`
3. `nix-build --argstr channelName nixpkgs-23.11 -A glibc` and see `glibc-2.38-44`