### PR TITLE
add flake compatability

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,10 @@
+{
+  outputs =
+    { self }:
+    let
+      system = "x86_64-linux";
+    in
+    {
+      legacyPackages.${system} = import ./. { inherit system; };
+    };
+}


### PR DESCRIPTION
Why
===
* If we want to add replit-nixpkgs as the default nixpkgs registry entry, it needs a flake entrypoint
  * Using our already cached nixpkgs as the default registry will dramaticaclly speed up flakes using the default `nixpkgs`

What changed
===
* Added simple flake for `nix registry` compatablity
